### PR TITLE
Added reboot onboard computers button

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -150,6 +150,14 @@ Item {
                                                          StandardButton.Cancel | StandardButton.Ok,
                                                          function() { _activeVehicle.rebootVehicle() })
         }
+        QGCMenuSeparator { }
+        QGCMenuItem {
+            text:           qsTr("Reboot Onboard Computers")
+            onTriggered:    mainWindow.showMessageDialog(qsTr("Reboot Onboard Computers"),
+                                                         qsTr("Select Ok to reboot all the onboard computers"),
+                                                         StandardButton.Cancel | StandardButton.Ok,
+                                                         function() { _activeVehicle.rebootOnboardComputers() })
+        }
     }
 
     /// Group buttons

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3604,6 +3604,20 @@ void Vehicle::rebootVehicle()
     sendMavCommandWithHandler(&handlerInfo, _defaultComponentId, MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN, 1);
 }
 
+void Vehicle::rebootOnboardComputers()
+{
+    // There can be four different onboard computers on the vehicle, so sending the reboot command to all of them
+    for (int i = 0; i < 4; ++i)
+    {
+        sendMavCommand(MAV_COMP_ID_ONBOARD_COMPUTER + i,
+                       MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
+                       false,                                                   // do not show errors
+                       0,                                                       // do nothing to autopilot
+                       3,                                                       // reboot onboard computer
+                       0, 0, 0, 0, 0);                                          // param 3-7 unused
+    }
+}
+
 void Vehicle::startCalibration(Vehicle::CalibrationType calType)
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -422,6 +422,9 @@ public:
     /// Reboot vehicle
     Q_INVOKABLE void rebootVehicle();
 
+    /// Reboot all onboard computers
+    Q_INVOKABLE void rebootOnboardComputers();
+
     /// Clear Messages
     Q_INVOKABLE void clearMessages();
 


### PR DESCRIPTION
"Reboot onboard computers" button that sends reboot command to all the companion computers on the vehicle

-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
* Connect to the autopilot
* Go to parameters and check whether there is a new option in the dropdown list
* Connect an onboard computer that accepts `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN` and make it visible to QGC via MavLink
* Click the newly added button

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.