### PR TITLE
Fix/settings caching

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -24,7 +24,7 @@ set(QGC_SETTINGS_VERSION "9" CACHE STRING "Settings schema version")
 # ============================================================================
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
-option(QGC_STABLE_BUILD "Stable release build (disables daily build features)" OFF)
+option(QGC_STABLE_BUILD "Stable release build (disables daily build features)" ON)
 option(QGC_USE_CACHE "Enable compiler caching (ccache/sccache)" ON)
 option(QGC_BUILD_INSTALLER "Build platform installers/packages" ON)
 

--- a/custom/src/FoxFourPlugin.cc
+++ b/custom/src/FoxFourPlugin.cc
@@ -46,7 +46,6 @@ bool FoxFourPlugin::overrideSettingsGroupVisibility(const QString& name) {
 
 VideoReceiver* FoxFourPlugin::createVideoReceiver(QObject* parent) {
 #ifdef QGC_GST_STREAMING
-    return QGCCorePlugin::createVideoReceiver(parent);
     return new FoxFourGstVideoReceiver(parent);
 #elif defined(QGC_QT_STREAMING)
     return QtMultimediaReceiver::createVideoReceiver(parent);

--- a/custom/src/FoxFourPlugin.cc
+++ b/custom/src/FoxFourPlugin.cc
@@ -13,7 +13,11 @@ QGC_LOGGING_CATEGORY(CustomLog, "FoxFour.Plugin")
 Q_APPLICATION_STATIC(FoxFourPlugin, _customPluginInstance);
 
 FoxFourPlugin::FoxFourPlugin(QObject* parent)
-    : QGCCorePlugin(parent), _options(new QGCOptions(this)), _parameterSetter(new ParameterSetter(this)) {
+    : QGCCorePlugin(parent){
+
+    QCoreApplication::setApplicationName("FoxFour-QGroundControl");
+    _options= new QGCOptions(this);
+    _parameterSetter = new ParameterSetter(this);
     _version = QString(QGC_CUSTOM_VERSION);
     _showAdvancedUI = true;
     (void)connect(this, &FoxFourPlugin::showAdvancedUIChanged, this, &FoxFourPlugin::_advancedChanged);


### PR DESCRIPTION
- Disable daily builds to prevent cache folder override
- Specify "FoxFour-QGroundControl" application name to specify cache save folder naming.